### PR TITLE
Add Timestamp to BaseTelegram and clean up TelegramParser

### DIFF
--- a/RS485 Monitor/src/TelegramParser.cs
+++ b/RS485 Monitor/src/TelegramParser.cs
@@ -38,6 +38,7 @@ public class TelegramParser
         public TelegramArgs(BaseTelegram t)
         {
             Telegram = t;
+            Telegram.Timestamp = DateTime.Now;
         }
     }
 
@@ -200,7 +201,7 @@ public class TelegramParser
         }
 
         // Check if we can convert 
-        if ( tg.Type == BaseTelegram.TelegramType.READ_RESPONSE)
+        if (tg.Type == BaseTelegram.TelegramType.READ_RESPONSE)
         {
             if (tg.Source == 0xAA && tg.Destination == 0x5A && tg.PDU.Length == 10)
             {

--- a/RS485 Monitor/src/Telegrams/BaseTelegram.cs
+++ b/RS485 Monitor/src/Telegrams/BaseTelegram.cs
@@ -57,6 +57,11 @@ public class BaseTelegram : IEquatable<BaseTelegram>
     /// </summary>
     public TelegramType Type { get => (TelegramType)Start; }
 
+    /// <summary>
+    /// Timestamp of the telegram
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
     #endregion
 
     #region Constants


### PR DESCRIPTION
Added a Timestamp property to the BaseTelegram class to store the creation or processing time of the telegram. Updated the TelegramArgs constructor in TelegramParser.cs to set this Timestamp to the current date and time (DateTime.Now) when a new TelegramArgs instance is created. Removed an unnecessary space in the TelegramParser class before the type check for the telegram.