### PR TITLE
22 - Introduced timestamp in BaseTelegram

### DIFF
--- a/RS485 Monitor/src/Telegrams/BaseTelegram.cs
+++ b/RS485 Monitor/src/Telegrams/BaseTelegram.cs
@@ -137,6 +137,11 @@ public class BaseTelegram : IEquatable<BaseTelegram>
     /// </summary>
     public TelegramType Type { get => (TelegramType)RawType; }
 
+    /// <summary>
+    /// Timestamp when the telegram was received / created
+    /// </summary>
+    public DateTime TimeStamp { get; }
+
     #endregion
 
     /// <summary>
@@ -165,11 +170,15 @@ public class BaseTelegram : IEquatable<BaseTelegram>
     /// Create a new base telegram based on the given raw data
     /// </summary>
     /// <param name="rawData">raw data of one telegram</param>
+    /// <param name="timestamp">
+    ///   Optional timestamp when the telegram was received. If it stays null,
+    ///   the current timestamp is used.
+    /// </param>
     /// <exception cref="ArgumentNullException">Raw data is null.</exception>
     /// <exception cref="ArgumentException">Raw data is too short.</exception>
     /// <exception cref="ArgumentException">Invalid data length in the raw data.</exception>
     /// <exception cref="ArgumentException">Raw data does not contain End tag.</exception>
-    public BaseTelegram(byte[] rawData)
+    public BaseTelegram(byte[] rawData, DateTime? timestamp = null)
     {
         // Basic validation
         ArgumentNullException.ThrowIfNull(rawData);
@@ -206,6 +215,9 @@ public class BaseTelegram : IEquatable<BaseTelegram>
             log.Error("RawData does not hold Endtag");
             throw new ArgumentException("Raw data does not contain End tag");
         }
+
+        // Set timestamp
+        TimeStamp = timestamp ?? DateTime.Now;
     }
 
     /// <summary>

--- a/tests/BaseTelegramTest.cs
+++ b/tests/BaseTelegramTest.cs
@@ -114,4 +114,26 @@ public class BaseTelegramTest
 
         Assert.That(telegram1.Equals(telegram2), Is.EqualTo(false));
     }
+
+    [Test]
+    public void AutomaticTimeStampCreated()
+    {
+        byte[] raw = [0xB6, 0x6B, 0xAA, 0xDA, 0x0A, 0x02, 0x00, 0x04, 0x00, 0x00, 0x13, 0x00, 0x00, 0x02, 0x01, 0x1C, 0x0D];
+
+        BaseTelegram telegram = new(raw);
+        var now = DateTime.Now;
+
+        Assert.That(telegram.TimeStamp.Ticks, Is.EqualTo(now.Ticks).Within(300));
+    }
+
+    [Test]
+    public void ManualTimeStampCreated()
+    {
+        byte[] raw = [0xB6, 0x6B, 0xAA, 0xDA, 0x0A, 0x02, 0x00, 0x04, 0x00, 0x00, 0x13, 0x00, 0x00, 0x02, 0x01, 0x1C, 0x0D];
+        DateTime timestamp = new(2021, 12, 24, 12, 0, 0);
+
+        BaseTelegram telegram = new(raw, timestamp);
+
+        Assert.That(telegram.TimeStamp, Is.EqualTo(timestamp));
+    }
 }


### PR DESCRIPTION
Introduced a readonly timestamp property for the `BaseTelegram` that is set automatically. Additionally, the timestamp can be set manually during creation.

Also added corresponding unit tests.

closes #22