### PR TITLE
24 - Timestamp offset in time view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ itself has been updated to dotnet 8.0 and is now using the new information
 - Introduced software unit tests [#17](https://github.com/stprograms/SuperSoco485Monitor/issues/17)
 - Introduced timestamp for telegrams [#22](https://github.com/stprograms/SuperSoco485Monitor/issues/22)
 - Introduced storing of telegrams with timestamp [#23](https://github.com/stprograms/SuperSoco485Monitor/issues/23)
+- Showing offset to previous telegram in time view [#24](https://github.com/stprograms/SuperSoco485Monitor/issues/24)
 
 ## 1.2.0
 ### Modified

--- a/RS485 Monitor/src/Utils/LogPrinter.cs
+++ b/RS485 Monitor/src/Utils/LogPrinter.cs
@@ -1,15 +1,25 @@
 using NLog;
 
 /// <summary>
-/// Simple class printing the telegram to the log
+/// Simple class printing the telegram to the log.
+///
+/// It will print the telegrams in the following format:
+/// - offset to the last telegram in milliseconds
+/// - Raw data of the telegram
+/// - Detailed string representation of the telegram
 /// </summary>
 public class LogPrinter : IUserVisualizable
 {
-
     /// <summary>
     /// class logger
     /// </summary>
     private static readonly Logger log = LogManager.GetCurrentClassLogger();
+    /// <summary>
+    /// Timestamp of the last printed telegram.
+    ///
+    /// If no telegram was printed yet, it is null.
+    /// </summary>
+    private DateTime? lastTelegramTimestamp = null;
 
     /// <summary>
     /// Flush output
@@ -25,6 +35,9 @@ public class LogPrinter : IUserVisualizable
     /// <param name="tg"></param>
     public void PrintTelegram(BaseTelegram tg)
     {
-        log.Info(tg.ToStringDetailed());
+        var offset = lastTelegramTimestamp.HasValue ? tg.TimeStamp - lastTelegramTimestamp.Value : TimeSpan.Zero;
+        lastTelegramTimestamp = tg.TimeStamp;
+
+        log.Info($"[{offset.TotalMilliseconds,5:N0} ms] {tg.ToStringDetailed()}");
     }
 }


### PR DESCRIPTION
Introduced writing the offset to the previous received telegram in the time view.

With this change, the timed view will print the telegram in the following format:
`[<offset> ms] <Raw data> -> <Parsed data>`


closes #24 